### PR TITLE
Evaluate functions completely in conda/condu

### DIFF
--- a/lib/minikanren.ex
+++ b/lib/minikanren.ex
@@ -389,7 +389,7 @@ defmodule MiniKanren do
       :mzero -> :mzero
       [_a | _f] -> bind(h, seq)
       pkg when is_tuple(pkg) -> bind(pkg, seq)
-      f  when is_function(f) -> fn -> __conda(f.(), seq) end
+      f  when is_function(f) -> __conda(f.(), seq)
     end
   end
   
@@ -439,7 +439,7 @@ defmodule MiniKanren do
       :mzero -> :mzero
       [a | _f] -> bind(unit(a), seq)
       pkg when is_tuple(pkg) -> bind(pkg, seq)
-      f  when is_function(f) -> fn -> __condu(f.(), seq) end
+      f  when is_function(f) -> __condu(f.(), seq)
     end
   end
   

--- a/test/impure_test.exs
+++ b/test/impure_test.exs
@@ -21,6 +21,24 @@ defmodule MKImpureTest do
       end
     end
   end
+
+	test "conda checks all assertions of function clause" do
+		bad_func = fn (_) ->
+			succeed()
+			conda do
+				[fail()]
+			end
+		end
+
+		result = run_all([x]) do
+			conda do
+				[bad_func.(x)]
+				[eq(x, :success)]
+			end
+		end
+
+		assert(result == [:success])
+	end
   
   test "condu ignores clauses after first success" do
     result = run_all([x]) do
@@ -41,6 +59,24 @@ defmodule MKImpureTest do
       end
     end
   end
+
+	test "condu checks all assertions of function clause" do
+		bad_func = fn (_) ->
+			succeed()
+			condu do
+				[fail()]
+			end
+		end
+
+		result = run_all([x]) do
+			condu do
+				[bad_func.(x)]
+				[membero(x, [1,2,3])]
+			end
+		end
+
+		assert(result == [1])
+	end
   
   test "onceo succeeds at most once" do
     result = run_all([x]) do


### PR DESCRIPTION
The current behavior in ExKanren is that if a function is passed to the
first clause of a conda/condu block, it would seem that as long as the
first sub-clause of that function is successful, the conda/condu will
consider that line "successful" and follow that path.

It is unclear in the "Thin Ice" chapter of _The Reasoned Schemer_ if
that is the desired behavior. However, when looking at clojure's
core.logic library, it would seem the function should be evaluated
completely.

```clojure
(ns ex-kanren
  #_=>   (:refer-clojure :exclude [==])
  #_=>   (:require [clojure.core.logic :refer :all]))

(defn latefail []
  #_=> (== 1 1)
  #_=> (conda
         #_=> [(== 1 2)]
         #_=> [(== 1 3)]
         #_=> ))

(run* [x]
      #_=> (conda
             #_=> [(latefail) (== x 0)]
             #_=> [(== 1 1) (== x 1)]
             #_=> )
      #_=> )

=> (1)
```

Current ExKanren behavior:

```elixir
use MiniKanren
alias MiniKanren, as: MK

latefail = fn() ->
  eq(1, 1)
  conda do
    [eq(1,2)]
  end
end

MK.run_all([x]) do
  conda do
    [latefail.(), eq(x, 0)]
    [eq(1,1), eq(x, 1)]
  end
end

=> []
```

In the above, since the first statement of latefil eq(1,1) succeeds, it
continues on but will fail and ultimately not bind x to 0.

Suggested ExKanren behavior:

```elixir
use MiniKanren
alias MiniKanren, as: MK

latefail = fn() ->
  eq(1, 1)
  conda do
    [eq(1,2)]
  end
end

MK.run_all([x]) do
  conda do
    [latefail.(), eq(x, 0)]
    [eq(1,1), eq(x, 1)]
  end
end

=> [1]
```

The failure of the latefail method should ultimately moved the conda
into the second sequence with eq(1,1) succeeding and assigning x to 1.

Admittedly, I am not sure if there are side effects in the way I
implemented the change, but I have not seen any yet.